### PR TITLE
window.console vs console

### DIFF
--- a/scoped.js
+++ b/scoped.js
@@ -52,7 +52,7 @@ var scopedPolyFill = ( function ( doc, undefined ) {
     if ( compat.scopeSupported )
         return function (){ return this};
 
-    console && console.log( "No support for <style scoped> found, commencing jumping through hoops in 3, 2, 1..." );
+    window.console && console.log( "No support for <style scoped> found, commencing jumping through hoops in 3, 2, 1..." );
 
     // this was called so we "scope" all the <style> nodes which need to be scoped now
     var scopedSheets


### PR DESCRIPTION
If console isn't defined, it'll throw a reference error.  So it should be either: 

```
typeof console !== undefined && console.log(...)
```

or

```
window.console.&& console.log(...)
```

(This will still throw a type error if someone defined console as something else, but I'm assuming sanity.)
