### PR TITLE
Added index to addRule to ensure order of rules

### DIFF
--- a/scoped.js
+++ b/scoped.js
@@ -167,7 +167,7 @@ var scopedPolyFill = ( function ( doc, undefined ) {
                     // IE doesn't allow inserting of '' as a styleRule
                     if (styleRule) {
                       sheet.removeRule    ? sheet.removeRule( index )             : sheet.deleteRule( index );
-                      sheet.addRule       ? sheet.addRule( selector, styleRule )  : sheet.insertRule( selector + '{' + styleRule + '}', index );
+                      sheet.addRule       ? sheet.addRule( selector, styleRule, index )  : sheet.insertRule( selector + '{' + styleRule + '}', index );
                     }
                 }
             }


### PR DESCRIPTION
I added the index parameter to addRule to ensure that in IE rules will be added in the correct order. The issue was that when you had two rules with the same selector (the second one to override the first) the second rule was being written first and therefore not overriding the first rule. The order of the two rules was reversed resulting in the incorrect rule being used.
